### PR TITLE
Fix release workflow to write outputs to runner's GITHUB_OUTPUT so gh-release receives tag

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,70 @@
+# This workflow will upload a Python Package to PyPI when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,69 @@
+name: Create Release on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  create-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Read package version from setup.py
+        id: package_version
+        run: |
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          setup_py = Path("setup.py").read_text(encoding="utf-8")
+          match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', setup_py)
+          if not match:
+              raise SystemExit("Could not find version in setup.py")
+
+          version = match.group(1)
+          output_path = os.environ.get("GITHUB_OUTPUT")
+          if not output_path:
+              raise SystemExit("GITHUB_OUTPUT is not set")
+
+          with open(output_path, "a", encoding="utf-8") as fh:
+              fh.write(f"version={version}\n")
+              fh.write(f"tag=v{version}\n")
+          PY
+
+      - name: Skip release if tag already exists
+        id: tag_check
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.package_version.outputs.tag }}" > /dev/null 2>&1; then
+            echo "create_release=false" >> "$GITHUB_OUTPUT"
+            echo "Tag already exists; skipping release creation."
+          else
+            echo "create_release=true" >> "$GITHUB_OUTPUT"
+            echo "Tag does not exist; release will be created."
+          fi
+
+      - name: Create GitHub release
+        if: steps.tag_check.outputs.create_release == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.package_version.outputs.tag }}
+          name: ${{ steps.package_version.outputs.tag }}
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          generate_release_notes: true
+          body: |
+            Automated release created after merging PR #${{ github.event.pull_request.number }}.


### PR DESCRIPTION
### Motivation
- Resolve the `GitHub Releases requires a tag` failure by ensuring the workflow step writes `version`/`tag` outputs to the runner-provided outputs file instead of a literal `$GITHUB_OUTPUT` filename. 
- Keep the existing flow of deriving `v<version>` from the package metadata and skipping release creation when the tag already exists. 
- Make the step robust to the heredoc quoting issue that prevented shell variable expansion and left `steps.package_version.outputs.tag` empty.

### Description
- Updated `.github/workflows/release-on-merge.yml` so the Python step imports `os` and reads the `GITHUB_OUTPUT` environment variable, erroring if it is not set, and writes `version=<...>` and `tag=v<...>` into that file. 
- Preserved the tag existence check and conditional creation of the GitHub Release via `softprops/action-gh-release@v2` using the `tag` output. 
- Left the `setup.py` version extraction logic intact and continued to derive the release tag as `v<version>`.

### Testing
- Inspected the updated workflow YAML to confirm the Python step now uses `os.environ.get("GITHUB_OUTPUT")` and writes to that path. 
- Ran a local Python simulation that set `GITHUB_OUTPUT` to a temporary file and verified the file contains `version=<version>` and `tag=v<version>`. 
- Verified `setup.py` exposes the expected version (currently `0.3.0`) which would produce `tag=v0.3.0` when the workflow runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c985bfb1883258d83d4853f8ba2e6)