### PR TITLE
Fix PyPI versioning and automated release workflow

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -31,6 +31,7 @@ jobs:
           import re
           from pathlib import Path
 
+          # Reading version from __init__.py as the single source of truth
           init_py = Path("pyspectools2/__init__.py").read_text(encoding="utf-8")
           match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', init_py)
           if not match:
@@ -57,20 +58,14 @@ jobs:
             echo "Tag does not exist; release will be created."
           fi
 
-      - name: Ensure release token is configured
-        if: steps.tag_check.outputs.create_release == 'true'
-        run: |
-          if [ -z "${{ secrets.RELEASE_TOKEN }}" ]; then
-            echo "RELEASE_TOKEN secret is required."
-            echo "Use a PAT (repo scope) so the created release triggers the release workflow."
-            exit 1
-          fi
-
       - name: Create GitHub release
         if: steps.tag_check.outputs.create_release == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # Using GITHUB_TOKEN for out-of-the-box functionality.
+          # Note: GITHUB_TOKEN will not trigger other workflows (like pypi-publish if it were on release event).
+          # Since pypi-publish.yml is also triggered on PR merge, this is acceptable.
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.package_version.outputs.tag }}
           name: ${{ steps.package_version.outputs.tag }}
           target_commitish: ${{ github.event.pull_request.merge_commit_sha }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
@@ -24,7 +24,6 @@ dependencies = [
 ]
 
 [tool.hatch.version]
-source = "vcs"
 path = "pyspectools2/__init__.py"
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
This PR fixes the issue where PyPI uploads were failing due to invalid local version identifiers generated by hatch-vcs. By switching to static versioning from __init__.py, we ensure that PyPI-compatible version strings are used.

Additionally, it fixes the 'Create Release on PR Merge' workflow by switching from a custom (and missing) RELEASE_TOKEN secret to the standard GITHUB_TOKEN, ensuring releases are correctly created upon merging.

Key changes:
- Removed hatch-vcs from pyproject.toml and set tool.hatch.version.path to pyspectools2/__init__.py.
- Modified .github/workflows/release-on-merge.yml to use GITHUB_TOKEN and added a comment explaining the choice.
- Verified the build and tests pass.

---
*PR created automatically by Jules for task [4617087957674597626](https://jules.google.com/task/4617087957674597626) started by @Ampter*