### PR TITLE
Change README imports to pyspectools2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pip install .
 ## Import
 
 ```python
-import pyspectools as pst
+import pyspectools2 as pst
 ```
 
 ## API
@@ -72,7 +72,7 @@ Prints the total size of the latest session folder.
 ## Usage Example
 
 ```python
-import pyspectools as pst
+import pyspectools2 as pst
 
 session_folder = pst.create_session_folder()
 audio_data = pst.record_audio(duration=5)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,3 +1,4 @@
+from bump_version import bump_version
 import sys
 import os
 from pathlib import Path
@@ -7,7 +8,7 @@ scripts_dir = Path(__file__).parent.parent / "scripts"
 sys.path.append(str(scripts_dir))
 
 # Import bump_version.py
-from bump_version import bump_version
+
 
 def test_bump_logic():
     test_cases = [

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,11 +1,13 @@
-from bump_version import bump_version
 import sys
 import os
 from pathlib import Path
+
 # Add scripts directory to sys.path
 scripts_dir = Path(__file__).parent.parent / "scripts"
 sys.path.append(str(scripts_dir))
 
+# Import bump_version.py
+from bump_version import bump_version
 
 def test_bump_logic():
     test_cases = [


### PR DESCRIPTION
Updated import statements from 'pyspectools' to 'pyspectools2' in the README.